### PR TITLE
refactor: Repository.move filters nodes instead of deleting their sha

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -588,11 +588,9 @@ class Repository extends Requestable {
                if (ref.path === oldPath) {
                   ref.path = newPath;
                }
-               if (ref.type === 'tree') {
-                  delete ref.sha;
-               }
                return ref;
-            });
+            })
+            .filter((ref) => ref.type !== 'tree');
             return this.createTree(newTree);
          })
          .then(({data: tree}) => this.commit(oldSha, tree.sha, `Renamed '${oldPath}' to '${newPath}'`))


### PR DESCRIPTION
closes #215

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for handling references in the repository to enhance commit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->